### PR TITLE
Update dockerfile to use golang's alpine base image

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,12 +31,12 @@ If you are developing a tidbyt pixlet app in a local folder, you can run this co
 
 ### Windows
 ``` bash
-docker run --rm -it -p 8080:8080 -v C:\src\pixlet-docker\examples:/srv pixlet pixlet serve -i 0.0.0.0 -w /srv/sports_scores.star
+docker run --rm -it -p 8080:8080 -v C:\src\pixlet-docker\examples:/srv pixlet ./pixlet serve -i 0.0.0.0 -w /srv/sports_scores.star
 ```
 
 ### Linux
 ``` bash
-docker run --rm -it -p 8080:8080 -v /usr/src/pixlet-docker/examples:/srv pixlet pixlet serve -i 0.0.0.0 -w /srv/sports_scores.star
+docker run --rm -it -p 8080:8080 -v /usr/src/pixlet-docker/examples:/srv pixlet ./pixlet serve -i 0.0.0.0 -w /srv/sports_scores.star
 ```
 
 

--- a/dockerfile
+++ b/dockerfile
@@ -1,15 +1,11 @@
-FROM alpine
-ENV GOPATH /usr/local/go
+FROM golang:alpine
 ENV REPO $GOPATH/pixlet
-ENV PATH "${PATH}:${GOPATH}/bin:${REPO}"
 
 #install prereqs
 RUN apk update && \
     apk upgrade -U && \
-    apk add curl wget git make libc-dev gcc ca-certificates npm libwebp-dev libwebp-tools patchelf gcompat && \
+    apk add curl wget git make libc-dev gcc npm libwebp-dev libwebp-tools patchelf gcompat && \
     rm -rf /var/cache/*
-RUN wget "https://go.dev/dl/$(curl 'https://go.dev/VERSION?m=text').linux-amd64.tar.gz" && tar -C /usr/local -xzf go*.linux-amd64.tar.gz && rm -f go*.linux-amd64.tar.gz
-RUN patchelf --set-interpreter /lib/libc.musl-x86_64.so.1 /usr/local/go/bin/go
 
 #Download Pixlet
 RUN git clone https://github.com/tidbyt/pixlet.git $REPO 


### PR DESCRIPTION
This PR replaces the bare Alpine docker base image with Golang's Alpine image, simplifying the dockerfile slightly and fixing the build issue.  